### PR TITLE
Updated Jinja to get rid of the security alert

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ alabaster==0.7.9
 Babel==2.3.4
 docutils==0.12
 imagesize==0.7.1
-Jinja2==2.8
+Jinja2>=2.10.1
 MarkupSafe==0.23
 Pygments==2.1.3
 pytz==2016.6.1


### PR DESCRIPTION
Jinja is only used for the documentation, so I'm updating this directly on master. If it breaks the docs I'll revert.