### PR TITLE
Fixed bug where datetime columns would cause warns

### DIFF
--- a/src/CSVelte/Taster.php
+++ b/src/CSVelte/Taster.php
@@ -825,7 +825,7 @@ class Taster
             }
             if (preg_match("/^{$date}$/i", $data)) {
                 return self::TYPE_DATE;
-            } elseif (preg_match("/^{$date} {$time}$/i")) {
+            } elseif (preg_match("/^{$date} {$time}$/i", $data)) {
                 return self::TYPE_DATETIME;
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
Datetime values cause warnings from the taster. I have included the errors below:

> PHP Warning:  preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> 
> Warning: preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> PHP Warning:  preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> 
> Warning: preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> PHP Warning:  preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> 
> Warning: preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> PHP Warning:  preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> 
> Warning: preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> PHP Warning:  preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> 
> Warning: preg_match() expects at least 2 parameters, 1 given in /Users/luke/PhpstormProjects/testcsv/vendor/nozavroni/csvelte/src/CSVelte/Taster.php on line 828
> array(3) {
>   [2]=>
>   array(9) {
>     ["Sentence"]=>
>     string(14) "this is a test"
>     ["Email"]=>
>     string(23) "thisisanemail@gmail.com"
>     ["SomeText"]=>
>     string(8) "not this"
>     ["Five Digits"]=>
>     string(6) "049458"
>     ["Some more text"]=>
>     string(0) ""
>     ["And more text"]=>
>     string(0) ""
>     ["Question"]=>
>     string(14) "What happened?"
>     ["Description"]=>
>     string(105) "This has to have quotes because it contains the delimiter, as well as some, other, crap
> 
> like line breaks"
>     ["DateColumn"]=>
>     string(20) "2020-04-23T00:00:01Z"
>   }
> # and so on...

